### PR TITLE
Add an option for the ImageReview backend to add annotations to the pods

### DIFF
--- a/pkg/apis/core/annotation_key_constants.go
+++ b/pkg/apis/core/annotation_key_constants.go
@@ -23,6 +23,10 @@ const (
 	// webhook backend fails.
 	ImagePolicyFailedOpenKey string = "alpha.image-policy.k8s.io/failed-open"
 
+	// ImagePolicyAuditRequired is recommended for image review backends to
+	// add when an pod is allowed to be created, but should be audited.
+	ImagePolicyAuditRequired string = "alpha.image-policy.k8s.io/audit-required"
+
 	// PodPresetOptOutAnnotationKey represents the annotation key for a pod to exempt itself from pod preset manipulation
 	PodPresetOptOutAnnotationKey string = "podpreset.admission.kubernetes.io/exclude"
 

--- a/pkg/apis/imagepolicy/types.go
+++ b/pkg/apis/imagepolicy/types.go
@@ -60,6 +60,11 @@ type ImageReviewContainerSpec struct {
 type ImageReviewStatus struct {
 	// Allowed indicates that all images were allowed to be run.
 	Allowed bool
+        // ReviewAnnotations should be added to the annotations of the pod.
+	// This may be used to later find pods that required audits. Annotations
+	// will only be added in case 'Allowed' is True.
+	// Annotations should be prefixed by 'alpha.image-policy.k8s.io'.
+	ReviewAnnotations map[string]string
 	// Reason should be empty unless Allowed is false in which case it
 	// may contain a short description of what is wrong.  Kubernetes
 	// may truncate excessively long errors when displaying to the user.

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -181,6 +181,13 @@ func (a *Plugin) admitPod(pod *api.Pod, attributes admission.Attributes, review 
 		return errors.New("one or more images rejected by webhook backend")
 	}
 
+	annotations := pod.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for k, v := range review.Status.ReviewAnnotations {
+		annotations[k] = v
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add an option to set pod annotations from the ImageReview admission controller.